### PR TITLE
Part1 & Part2 : NULL tests (as option)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ Run only some tests
 	# e.g. To launch only the test 05 you can use
 	make ft_ls tests=^05
 
+Don't run NULL tests (libft)
+
+	Assign 0 to -DTESTNULL in Makefile (libft_tests) (respectively 1 if you want
+	to run NULL tests).
+
 Notes
 ---
 GNL

--- a/libft_tests/Makefile
+++ b/libft_tests/Makefile
@@ -4,7 +4,7 @@ SOURCE = ../testframework/*.c main.c ./part1/*.c utils.c
 tests ?= spec.c$$
 RENDU_PATH = $(shell grep LIBFT_PATH ../config.ini | cut -d '=' -f 2)
 PROTOTYPES = $(shell ls -1 part1 part2 bonus extra | grep -v ':' | sed -E "s/(.*)\.spec\.c/UT_TEST\(\1\);/g")
-DEFINES = -DPROTOTYPES="$(PROTOTYPES)" -DRENDU_PATH="\"$(RENDU_PATH)\""
+DEFINES = -DPROTOTYPES="$(PROTOTYPES)" -DRENDU_PATH="\"$(RENDU_PATH)\"" -DTESTNULL=1
 INCLUDES = -I $(RENDU_PATH) -I $(RENDU_PATH)/includes -I ../testframework -I.
 PARTS_DIRS = part1
 

--- a/libft_tests/part1/ft_bzero.spec.c
+++ b/libft_tests/part1/ft_bzero.spec.c
@@ -11,7 +11,6 @@ UT_TEST(ft_bzero)
 	ft_bzero(b1, 0);
 	UT_ASSERT_EQ(b1[0], 1);
 
-	/* test edge cases */
-	bzero(NULL, 0);
-	ft_bzero(NULL, 0);
+	if (TESTNULL)
+		ft_bzero(NULL, 0);
 }

--- a/libft_tests/part1/ft_memccpy.spec.c
+++ b/libft_tests/part1/ft_memccpy.spec.c
@@ -17,4 +17,11 @@ UT_TEST(ft_memccpy)
 	char dest[] = "abcdefghijklmnopqrstuvwxyz";
 	UT_ASSERT_EQ(ft_memccpy(dest, strdup("test\200string"), '\200', 12),
 		memccpy(dest, strdup("test\200string"), '\200', 12));
+
+	if (TESTNULL)
+	{
+		ft_memccpy(NULL, dest, 0, 0);
+		ft_memccpy(dest, NULL, 0, 0);
+		ft_memccpy(NULL, NULL, 0, 0);
+	}
 }

--- a/libft_tests/part1/ft_memchr.spec.c
+++ b/libft_tests/part1/ft_memchr.spec.c
@@ -37,7 +37,10 @@ UT_TEST(ft_memchr)
 		++i;
 	}
 
-	ft_memchr(NULL, 0, 0);
-	ft_memchr(NULL, 0, 10);
-	ft_memchr(NULL, -10, 10);
+	if (TESTNULL)
+	{
+		ft_memchr(NULL, 0, 0);
+		ft_memchr(NULL, 0, 10);
+		ft_memchr(NULL, -10, 10);
+	}
 }

--- a/libft_tests/part1/ft_memcmp.spec.c
+++ b/libft_tests/part1/ft_memcmp.spec.c
@@ -10,4 +10,11 @@ UT_TEST(ft_memcmp)
 	UT_ASSERT_EQ(ft_memcmp("aab", "aac", 2), 0);
 	UT_ASSERT_EQ(ft_memcmp("aww", "bpp", 0), 0);
 	UT_ASSERT(ft_memcmp("\200", "\0", 1) > 0);
+
+	if (TESTNULL)
+	{
+		ft_memcmp(NULL, "42", 0);
+		ft_memcmp("42", NULL, 0);
+		ft_memcmp(NULL, NULL, 0);
+	}
 }

--- a/libft_tests/part1/ft_memcpy.spec.c
+++ b/libft_tests/part1/ft_memcpy.spec.c
@@ -11,6 +11,6 @@ UT_TEST(ft_memcpy)
 	UT_ASSERT(memcmp(b1, b2, 100) == 0);
 	UT_ASSERT(ft_memcpy(b1, b2, 0) == b1);
 
-	/* test edge cases */
-	ft_memcpy(NULL, NULL, 0);
+	if (TESTNULL)
+		ft_memcpy(NULL, NULL, 0);
 }

--- a/libft_tests/part1/ft_memmove.spec.c
+++ b/libft_tests/part1/ft_memmove.spec.c
@@ -37,4 +37,11 @@ UT_TEST(ft_memmove)
 	memmove(NULL, test, -100);
 	memmove(test, NULL, -100);
 	*/
+
+	if (TESTNULL)
+	{
+		ft_memmove(NULL, "42", 42);
+		ft_memmove("42", NULL, 42);
+		ft_memmove(NULL, NULL, 42);
+	}
 }

--- a/libft_tests/part1/ft_memset.spec.c
+++ b/libft_tests/part1/ft_memset.spec.c
@@ -18,4 +18,7 @@ UT_TEST(ft_memset)
 	ft_memset(0, 0, 0);
 	ft_memset(0, 'A', 0);
 	UT_ASSERT(memcmp(memset(strdup("abcd"), 0, 0), ft_memset(strdup("abcd"), 0, 0), 5) == 0);
+
+	if (TESTNULL)
+		ft_memset(NULL, 0, 0);
 }

--- a/libft_tests/part1/ft_strcat.spec.c
+++ b/libft_tests/part1/ft_strcat.spec.c
@@ -12,4 +12,11 @@ UT_TEST(ft_strcat)
 	ft_strcat(buf, "");
 	UT_ASSERT_EQ(strcmp(buf, "Bonjour."), 0);
 	UT_ASSERT_EQ(buf, ft_strcat(buf, ""));
+
+	if (TESTNULL)
+	{
+		ft_strcat(NULL, "42");
+		ft_strcat("42", NULL);
+		ft_strcat(NULL, NULL);
+	}
 }

--- a/libft_tests/part1/ft_strchr.spec.c
+++ b/libft_tests/part1/ft_strchr.spec.c
@@ -8,4 +8,7 @@ UT_TEST(ft_strchr)
 	UT_ASSERT_EQ(strchr(buf, 0), ft_strchr(buf, 0));
 	UT_ASSERT_EQ(ft_strchr(buf, 'J'), buf);
 	UT_ASSERT_EQ(ft_strchr(buf, 'z'), 0);
+
+	if (TESTNULL)
+		ft_strchr(NULL, 0);
 }

--- a/libft_tests/part1/ft_strcmp.spec.c
+++ b/libft_tests/part1/ft_strcmp.spec.c
@@ -7,4 +7,11 @@ UT_TEST(ft_strcmp)
 	UT_ASSERT(ft_strcmp("abc", "abd") < 0);
 	UT_ASSERT(ft_strcmp("\200", "\0") > 0);
 	UT_ASSERT_NEQ(ft_strcmp("a", "abcde"), 0);
+
+	if (TESTNULL)
+	{
+		ft_strcmp(NULL, "42");
+		ft_strcmp("42", NULL);
+		ft_strcmp(NULL, NULL);
+	}
 }

--- a/libft_tests/part1/ft_strcpy.spec.c
+++ b/libft_tests/part1/ft_strcpy.spec.c
@@ -9,4 +9,11 @@ UT_TEST(ft_strcpy)
 
 	UT_ASSERT_EQ(strcmp(ft_strcpy(buf1, "abcde"), strcpy(buf1, "abcde")), 0);
 	UT_ASSERT_EQ(strcmp(ft_strcpy(buf1, "abc"), strcpy(buf1, "abc")), 0);
+
+	if (TESTNULL)
+	{
+		ft_strcpy(NULL, "42");
+		ft_strcpy("42", NULL);
+		ft_strcpy(NULL, NULL);
+	}
 }

--- a/libft_tests/part1/ft_strdup.spec.c
+++ b/libft_tests/part1/ft_strdup.spec.c
@@ -8,4 +8,7 @@ UT_TEST(ft_strdup)
 	UT_ASSERT_EQ(strcmp(ft_strdup("aaaaa"), "aaaaa"), 0);
 	UT_ASSERT_EQ(strcmp(ft_strdup(""), ""), 0);
 	UT_ASSERT_NEQ(c, ft_strdup(c));
+
+	if (TESTNULL)
+		ft_strdup(NULL);
 }

--- a/libft_tests/part1/ft_strlen.spec.c
+++ b/libft_tests/part1/ft_strlen.spec.c
@@ -5,4 +5,7 @@ UT_TEST(ft_strlen)
 	UT_ASSERT_EQ(ft_strlen("chat"), strlen("chat"));
 	UT_ASSERT_EQ(ft_strlen(""), strlen(""));
 	UT_ASSERT_EQ(ft_strlen("aaa\0aaa"), strlen("aaa\0aaa"));
+
+	if (TESTNULL)
+		ft_strlen(NULL);
 }

--- a/libft_tests/part1/ft_strncat.spec.c
+++ b/libft_tests/part1/ft_strncat.spec.c
@@ -10,4 +10,11 @@ UT_TEST(ft_strncat)
 	ft_strncat(buf, "efefef", 0);
 	UT_ASSERT_EQ(strcmp(buf, "To be or not"), 0);
 	UT_ASSERT_EQ(buf, ft_strncat(buf, "", 0));
+
+	if (TESTNULL)
+	{
+		ft_strncat(NULL, "42", 42);
+		ft_strncat("42", NULL, 42);
+		ft_strncat(NULL, NULL, 42);
+	}
 }

--- a/libft_tests/part1/ft_strncmp.spec.c
+++ b/libft_tests/part1/ft_strncmp.spec.c
@@ -7,4 +7,11 @@ UT_TEST(ft_strncmp)
 	UT_ASSERT_EQ(ft_strncmp("abc", "abc\0defg", 100), 0);
 	UT_ASSERT_NEQ(ft_strncmp("ab\0cde", "abcc\0e", 20), 0);
 	UT_ASSERT_EQ(ft_strncmp("q", "a", 0), strncmp("q", "a", 0));
+
+	if (TESTNULL)
+	{
+		ft_strncmp(NULL, "42", 42);
+		ft_strncmp("42", NULL, 42);
+		ft_strncmp(NULL, NULL, 42);
+	}
 }

--- a/libft_tests/part1/ft_strncpy.spec.c
+++ b/libft_tests/part1/ft_strncpy.spec.c
@@ -10,5 +10,10 @@ UT_TEST(ft_strncpy)
 	ft_strncpy(buf, "abcdefghi", 6);
 	UT_ASSERT_EQ(memcmp(buf, "abcdefghi", 6), 0);
 
-	ft_strncpy(NULL, NULL, 0);
+	if (TESTNULL)
+	{
+		ft_strncpy(NULL, NULL, 0);
+		ft_strncpy(NULL, "42", 42);
+		ft_strncpy("42", NULL, 42);
+	}
 }

--- a/libft_tests/part1/ft_strrchr.spec.c
+++ b/libft_tests/part1/ft_strrchr.spec.c
@@ -9,4 +9,10 @@ UT_TEST(ft_strrchr)
 	UT_ASSERT_EQ(ft_strrchr(buf, 'z'), 0);
 	buf[5] = 0;
 	UT_ASSERT_EQ(ft_strrchr(buf, 'a'), buf);
+
+	if (TESTNULL)
+	{
+		ft_strrchr(NULL, 'a');
+		ft_strrchr(NULL, 0);
+	}
 }

--- a/libft_tests/part1/ft_strstr.spec.c
+++ b/libft_tests/part1/ft_strstr.spec.c
@@ -13,4 +13,11 @@ UT_TEST(ft_strstr)
 	UT_ASSERT_EQ(strstr(buf2, "ozaraboze"), ft_strstr(buf2, "ozaraboze"));
 	UT_ASSERT_EQ(ft_strstr(buf, "BWAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"), NULL);
 	UT_ASSERT(strstr("", "") == ft_strstr("", ""));
+
+	if (TESTNULL)
+	{
+		ft_strstr(NULL, "42");
+		ft_strstr("42", NULL);
+		ft_strstr(NULL, NULL);
+	}
 }

--- a/libft_tests/part2/ft_memdel.spec.c
+++ b/libft_tests/part2/ft_memdel.spec.c
@@ -8,9 +8,11 @@ UT_TEST(ft_memdel)
 	ft_memdel(&mem);
 	UT_ASSERT_W(mem == NULL);
 
-	/* test edge cases */
-	// void	*mem2;
-	// mem2 = NULL;
-	// ft_memdel(NULL);
-	// ft_memdel(&mem2);
+	if (TESTNULL)
+	{
+		void	*mem2;
+		mem2 = NULL;
+		ft_memdel(&mem2);
+		ft_memdel(NULL);
+	}
 }

--- a/libft_tests/part2/ft_strclr.spec.c
+++ b/libft_tests/part2/ft_strclr.spec.c
@@ -6,4 +6,7 @@ UT_TEST(ft_strclr)
 
 	ft_strclr(str);
 	UT_ASSERT_EQ(memcmp(str, "\0\0\0\0\0\0", 7), 0);
+
+	if (TESTNULL)
+		ft_strclr(NULL);
 }

--- a/libft_tests/part2/ft_strdel.spec.c
+++ b/libft_tests/part2/ft_strdel.spec.c
@@ -7,4 +7,12 @@ UT_TEST(ft_strdel)
 	str = malloc(123);
 	ft_strdel(&str);
 	UT_ASSERT_EQ(str, NULL);
+
+	if (TESTNULL)
+	{
+		char *test;
+		test = NULL;
+		ft_strdel(&test);
+		ft_strdel(NULL);
+	}
 }

--- a/libft_tests/part2/ft_strequ.spec.c
+++ b/libft_tests/part2/ft_strequ.spec.c
@@ -5,4 +5,11 @@ UT_TEST(ft_strequ)
 	UT_ASSERT_EQ(ft_strequ("", ""), 1);
 	UT_ASSERT_EQ(ft_strequ("abcDEF", "abcDEF"), 1);
 	UT_ASSERT_EQ(ft_strequ("abcDEF", "abcDEf"), 0);
+
+	if (TESTNULL)
+	{
+		ft_strequ(NULL, "42");
+		ft_strequ("42", NULL);
+		ft_strequ(NULL, NULL);
+	}
 }

--- a/libft_tests/part2/ft_striter.spec.c
+++ b/libft_tests/part2/ft_striter.spec.c
@@ -6,4 +6,7 @@ UT_TEST(ft_striter)
 
 	ft_striter(str, it_test);
 	UT_ASSERT_EQ(strcmp(str, "bCdEfG"), 0);
+
+	if (TESTNULL)
+		ft_striter(NULL, it_test);
 }

--- a/libft_tests/part2/ft_striteri.spec.c
+++ b/libft_tests/part2/ft_striteri.spec.c
@@ -6,4 +6,7 @@ UT_TEST(ft_striteri)
 
 	ft_striteri(str, iti_test);
 	UT_ASSERT_EQ(strcmp(str, "aCeGiK"), 0);
+
+	if (TESTNULL)
+		ft_striteri(NULL, iti_test);
 }

--- a/libft_tests/part2/ft_strjoin.spec.c
+++ b/libft_tests/part2/ft_strjoin.spec.c
@@ -5,7 +5,10 @@ UT_TEST(ft_strjoin)
 	UT_ASSERT_EQ(strcmp(ft_strjoin("abc", "def"), "abcdef"), 0);
 	UT_ASSERT_EQ(strcmp(ft_strjoin("", ""), ""), 0);
 
-	ft_strjoin("", NULL);
-	ft_strjoin(NULL, "");
-	ft_strjoin(NULL, NULL);
+	if (TESTNULL)
+	{
+		ft_strjoin("", NULL);
+		ft_strjoin(NULL, "");
+		ft_strjoin(NULL, NULL);
+	}
 }

--- a/libft_tests/part2/ft_strmap.spec.c
+++ b/libft_tests/part2/ft_strmap.spec.c
@@ -11,4 +11,7 @@ UT_TEST(ft_strmap)
 	free(src); src = NULL;
 
 	UT_ASSERT_EQ(strcmp(dst, "bcdef"), 0);
+
+	if (TESTNULL)
+		ft_strmap(NULL, map_test);
 }

--- a/libft_tests/part2/ft_strmapi.spec.c
+++ b/libft_tests/part2/ft_strmapi.spec.c
@@ -11,4 +11,7 @@ UT_TEST(ft_strmapi)
 	free(src); src = NULL;
 
 	UT_ASSERT_EQ(strcmp(dst, "acegi"), 0);
+
+	if (TESTNULL)
+		ft_strmapi(NULL, mapi_test);
 }

--- a/libft_tests/part2/ft_strnequ.spec.c
+++ b/libft_tests/part2/ft_strnequ.spec.c
@@ -6,4 +6,11 @@ UT_TEST(ft_strnequ)
 	UT_ASSERT_EQ(ft_strnequ("abcde", "abdfe", 2), 1);
 	UT_ASSERT_EQ(ft_strnequ("abc", "abc", 100), 1);
 	UT_ASSERT_EQ(ft_strnequ("abcde", "abdde", 5), 0);
+
+	if (TESTNULL)
+	{
+		ft_strnequ(NULL, "42", 42);
+		ft_strnequ("42", NULL, 42);
+		ft_strnequ(NULL, NULL, 42);
+	}
 }

--- a/libft_tests/part2/ft_strsplit.spec.c
+++ b/libft_tests/part2/ft_strsplit.spec.c
@@ -26,5 +26,6 @@ UT_TEST(ft_strsplit)
 	tt = ft_strsplit("", '*');
 	UT_ASSERT(tt &&  tt[0] == NULL);
 
-	ft_strsplit(NULL, 0);
+	if (TESTNULL)
+		ft_strsplit(NULL, 0);
 }

--- a/libft_tests/part2/ft_strsub.spec.c
+++ b/libft_tests/part2/ft_strsub.spec.c
@@ -7,4 +7,7 @@ UT_TEST(ft_strsub)
 	UT_ASSERT_EQ(ft_strsub(str, 0, (size_t)-10), NULL);
 	UT_ASSERT_EQ(strcmp(ft_strsub(str, 8, 8), "je serai"), 0);
 	UT_ASSERT_EQ(strcmp(ft_strsub(str, 0, 0), ""), 0);
+
+	if (TESTNULL)
+		ft_strsub(NULL, 0, 0);
 }

--- a/libft_tests/part2/ft_strtrim.spec.c
+++ b/libft_tests/part2/ft_strtrim.spec.c
@@ -7,5 +7,6 @@ UT_TEST(ft_strtrim)
 	UT_ASSERT_EQ(strcmp(ft_strtrim(""), ""), 0);
 	UT_ASSERT_EQ(strcmp(ft_strtrim("abc"), "abc"), 0);
 
-	ft_strtrim(NULL);
+	if (TESTNULL)
+		ft_strtrim(NULL);
 }


### PR DESCRIPTION
Add null tests for each function which takes a pointer as argument.

NULL tests are an option which can be removed by assign 0 to DTESTNULL in Makefile (libft_tests).

And, in ft_bzero test, the instruction bzero(NULL) is useless because it takes a non-null argument.