### PR TITLE
Update test_print.c

### DIFF
--- a/testframework/v3/test/test_print.c
+++ b/testframework/v3/test/test_print.c
@@ -1,6 +1,7 @@
 #include <test.h>
 #include <stdio.h>
 #include <color.h>
+#include <signal.h>
 
 void	test_print(t_lst_elem *elem)
 {


### PR DESCRIPTION
Missing SIGXXX defines when compiling on Debian.