### PR TITLE
allow gnl tests to compile with -pedantic

### DIFF
--- a/get_next_line_tests/tests/05_test_error_handling.spec.c
+++ b/get_next_line_tests/tests/05_test_error_handling.spec.c
@@ -2,15 +2,15 @@
 
 static void simple_string(t_test *test)
 {
+    char 	*line = NULL;
+    
 	mt_assert(get_next_line(-99, NULL) == -1);
 	mt_assert(get_next_line(-1, NULL) == -1);
 	mt_assert(get_next_line(1, NULL) == -1);
 	mt_assert(get_next_line(99, NULL) == -1);
 
-	char 	*line = NULL;
 	mt_assert(get_next_line(-99, &line) == -1);
 	mt_assert(get_next_line(-1, &line) == -1);
-	// UT_ASSERT_NEQ(get_next_line(0, &line), -1);
 
 	/* Not opened fd */
 	mt_assert(get_next_line(42, &line) == -1);

--- a/get_next_line_tests/tests/30_bonus_multiple_fd.spec.c
+++ b/get_next_line_tests/tests/30_bonus_multiple_fd.spec.c
@@ -6,33 +6,37 @@ static void simple_string(t_test *test)
 	int		p0[2];
 	int		fd0 = 0;
 	int		out0 = dup(fd0);
-	pipe(p0);
-	dup2(p0[1], fd0);
-	write(fd0, "aaa\nbbb\n", 12);
-	dup2(out0, fd0);
 
 	char 	*line_fd1;
 	int		p_fd1[2];
 	int		fd1 = 1;
 	int		out_fd1 = dup(fd1);
-	pipe(p_fd1);
-	dup2(p_fd1[1], fd1);
-	write(fd1, "111\n222\n", 12);
-	dup2(out_fd1, fd1);
-
+    
 	char 	*line_fd2;
 	int		p_fd2[2];
 	int		fd2 = 2;
 	int		out_fd2 = dup(fd2);
+    
+    char 	*line_fd3;
+	int		p_fd3[2];
+	int		fd3 = 3;
+	int		out_fd3 = dup(fd3);
+    
+	pipe(p0);
+	dup2(p0[1], fd0);
+	write(fd0, "aaa\nbbb\n", 12);
+	dup2(out0, fd0);
+    
+	pipe(p_fd1);
+	dup2(p_fd1[1], fd1);
+	write(fd1, "111\n222\n", 12);
+	dup2(out_fd1, fd1);
+    
 	pipe(p_fd2);
 	dup2(p_fd2[1], fd2);
 	write(fd2, "www\nzzz\n", 12);
 	dup2(out_fd2, fd2);
 
-	char 	*line_fd3;
-	int		p_fd3[2];
-	int		fd3 = 3;
-	int		out_fd3 = dup(fd3);
 	pipe(p_fd3);
 	dup2(p_fd3[1], fd3);
 	write(fd3, "888\n999\n", 12);

--- a/get_next_line_tests/tests/41_hard_test_large_file.spec.c
+++ b/get_next_line_tests/tests/41_hard_test_large_file.spec.c
@@ -2,13 +2,14 @@
 
 static void simple_string(t_test *test)
 {
-	system("mkdir -p sandbox");
-	system("openssl rand -out sandbox/large_file.txt -base64 $((2**19 * 3/4))");
-
 	char *line;
 	int fd;
 	int fd2;
-
+	int fd3;
+	int	diff_file_size;
+    
+    system("mkdir -p sandbox");
+	system("openssl rand -out sandbox/large_file.txt -base64 $((2**19 * 3/4))");
 
 	fd = open("sandbox/large_file.txt", O_RDONLY);
 	fd2 = open("sandbox/large_file.txt.mine", O_CREAT | O_RDWR | O_TRUNC, 0755);
@@ -23,8 +24,6 @@ static void simple_string(t_test *test)
 	close(fd);
 	close(fd2);
 
-	int fd3;
-	int	diff_file_size;
 	system("diff sandbox/large_file.txt sandbox/large_file.txt.mine > sandbox/large_file.diff");
 	fd3 = open("sandbox/large_file.diff", O_RDONLY);
 	diff_file_size = read(fd3, NULL, 10);

--- a/get_next_line_tests/tests/42_hard_test_one_big_fat_line.spec.c
+++ b/get_next_line_tests/tests/42_hard_test_one_big_fat_line.spec.c
@@ -2,14 +2,15 @@
 
 static void simple_string(t_test *test)
 {
-	system("mkdir -p sandbox");
-	system("openssl rand -base64 $((2**15 * 3/4)) | tr -d '\n' | tr -d '\r' > sandbox/one_big_fat_line.txt");
-	system("echo '\n' >> sandbox/one_big_fat_line.txt");
-
 	char *line;
 	int fd;
 	int fd2;
-
+	int fd3;
+	int	diff_file_size;
+    
+    system("mkdir -p sandbox");
+	system("openssl rand -base64 $((2**15 * 3/4)) | tr -d '\n' | tr -d '\r' > sandbox/one_big_fat_line.txt");
+	system("echo '\n' >> sandbox/one_big_fat_line.txt");
 
 	fd = open("sandbox/one_big_fat_line.txt", O_RDONLY);
 	fd2 = open("sandbox/one_big_fat_line.txt.mine", O_CREAT | O_RDWR | O_TRUNC, 0755);
@@ -24,8 +25,6 @@ static void simple_string(t_test *test)
 	close(fd);
 	close(fd2);
 
-	int fd3;
-	int	diff_file_size;
 	system("diff sandbox/one_big_fat_line.txt sandbox/one_big_fat_line.txt.mine > sandbox/one_big_fat_line.diff");
 	fd3 = open("sandbox/one_big_fat_line.diff", O_RDONLY);
 	diff_file_size = read(fd3, NULL, 10);


### PR DESCRIPTION
```ISO C90 forbids mixed declarations and code [-Werror=pedantic]```

Keeping the declarations to the top.