### PR TITLE
More tests for ft_printf and ft_ls.

### DIFF
--- a/ft_ls_tests/tests/69_empty_argument_tests.spec.c
+++ b/ft_ls_tests/tests/69_empty_argument_tests.spec.c
@@ -1,0 +1,114 @@
+#include <project.h>
+
+static	char *cmd;
+static	char *ls_out_str;
+static	char *ft_ls_out_str;
+
+static void unitTest_00(t_test *test)
+{
+	cmd = "\"\"";
+	reset_sandbox();
+	sandbox_cmd("mkdir dirA && touch aa bb cc dirA/aa dirA/bb dirA/cc");
+	mt_assert(strcmp(ls(cmd), ft_ls(cmd)) == 0);
+}
+
+static void unitTest_01(t_test *test)
+{
+	cmd = "-l \"\"";
+	reset_sandbox();
+	sandbox_cmd("mkdir dirA && touch aa bb cc dirA/aa dirA/bb dirA/cc");
+	mt_assert(strcmp(ls(cmd), ft_ls(cmd)) == 0);
+}
+
+static void unitTest_02(t_test *test)
+{
+	cmd = "-l \"\" -R";
+	reset_sandbox();
+	sandbox_cmd("mkdir dirA && touch aa bb cc dirA/aa dirA/bb dirA/cc");
+	mt_assert(strcmp(ls(cmd), ft_ls(cmd)) == 0);
+}
+
+static void unitTest_03(t_test *test)
+{
+	cmd = "-lR . \"\" .";
+	reset_sandbox();
+	sandbox_cmd("mkdir dirA && touch aa bb cc dirA/aa dirA/bb dirA/cc");
+	mt_assert(strcmp(ls(cmd), ft_ls(cmd)) == 0);
+}
+
+static void unitTest_04(t_test *test)
+{
+	cmd = "-~ \"\"";
+	reset_sandbox();
+	sandbox_cmd("mkdir dirA && touch aa bb cc dirA/aa dirA/bb dirA/cc");
+	ft_ls_out_str = strip_illegal_opt_err(ft_ls(cmd));
+	ls_out_str = strip_illegal_opt_err(ls(cmd));
+	// print_ls_debug(cmd);
+	mt_assert(strcmp(ls_out_str, ft_ls_out_str) == 0);
+}
+
+static void unitTest_05(t_test *test)
+{
+	cmd = "\"\" -~";
+	reset_sandbox();
+	sandbox_cmd("mkdir dirA && touch aa bb cc dirA/aa dirA/bb dirA/cc");
+	ft_ls_out_str = strip_illegal_opt_err(ft_ls(cmd));
+	ls_out_str = strip_illegal_opt_err(ls(cmd));
+	// print_ls_debug(cmd);
+	mt_assert(strcmp(ls_out_str, ft_ls_out_str) == 0);
+}
+
+static void unitTest_06(t_test *test)
+{
+	cmd = "aa \"\" bb";
+	reset_sandbox();
+	sandbox_cmd("mkdir dirA && touch aa bb cc dirA/aa dirA/bb dirA/cc");
+	mt_assert(strcmp(ls(cmd), ft_ls(cmd)) == 0);
+}
+
+static void unitTest_07(t_test *test)
+{
+	cmd = "\"\" aa bb";
+	reset_sandbox();
+	sandbox_cmd("mkdir dirA && touch aa bb cc dirA/aa dirA/bb dirA/cc");
+	mt_assert(strcmp(ls(cmd), ft_ls(cmd)) == 0);
+}
+
+static void unitTest_08(t_test *test)
+{
+	cmd = "aa bb \"\"";
+	reset_sandbox();
+	sandbox_cmd("mkdir dirA && touch aa bb cc dirA/aa dirA/bb dirA/cc");
+	mt_assert(strcmp(ls(cmd), ft_ls(cmd)) == 0);
+}
+
+static void unitTest_09(t_test *test)
+{
+	cmd = "aa \"\" dne";
+	reset_sandbox();
+	sandbox_cmd("mkdir dirA && touch aa bb cc dirA/aa dirA/bb dirA/cc");
+	mt_assert(strcmp(ls(cmd), ft_ls(cmd)) == 0);
+}
+
+static void unitTest_10(t_test *test)
+{
+	cmd = "dne \"\" aa";
+	reset_sandbox();
+	sandbox_cmd("mkdir dirA && touch aa bb cc dirA/aa dirA/bb dirA/cc");
+	mt_assert(strcmp(ls(cmd), ft_ls(cmd)) == 0);
+}
+
+void	suite_69_empty_argument_tests(t_suite *suite)
+{
+	SUITE_ADD_TEST(suite, unitTest_00);
+	SUITE_ADD_TEST(suite, unitTest_01);
+	SUITE_ADD_TEST(suite, unitTest_02);
+	SUITE_ADD_TEST(suite, unitTest_03);
+	SUITE_ADD_TEST(suite, unitTest_04);
+	SUITE_ADD_TEST(suite, unitTest_05);
+	SUITE_ADD_TEST(suite, unitTest_06);
+	SUITE_ADD_TEST(suite, unitTest_07);
+	SUITE_ADD_TEST(suite, unitTest_08);
+	SUITE_ADD_TEST(suite, unitTest_09);
+	SUITE_ADD_TEST(suite, unitTest_10);
+}

--- a/ft_printf_tests/tests/52_min_width_flag_zero.spec.c
+++ b/ft_printf_tests/tests/52_min_width_flag_zero.spec.c
@@ -25,10 +25,34 @@ static void test_min_width_larger_than_input(t_test *test)
 	assert_printf("{%030d}", 10000);
 }
 
+static void test_min_width_with_hexa(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("{%030x}", 0xFFFF);
+}
+
+static void test_min_width_with_hexa_caps(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("{%030X}", 0xFFFF);
+}
+
 static void char_posMinWidth_zeroFlag(t_test *test)
 {
 	// test->debug = 1;
 	assert_printf("{%03c}", 0);
+}
+
+static void str_posMinWidth_zeroFlag(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("{%05s}", "abc");
+}
+
+static void wide_str_posMinWidth_zeroFlag(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("{%030S}", L"我是一只猫。");
 }
 
 static void pointer_posMinWidth_zeroFlag(t_test *test)
@@ -49,7 +73,11 @@ void	suite_52_min_width_flag_zero(t_suite *suite)
 	SUITE_ADD_TEST(suite, test_negative_value);
 	SUITE_ADD_TEST(suite, test_min_width_smaller_than_input);
 	SUITE_ADD_TEST(suite, test_min_width_larger_than_input);
+	SUITE_ADD_TEST(suite, test_min_width_with_hexa);
+	SUITE_ADD_TEST(suite, test_min_width_with_hexa_caps);
 	SUITE_ADD_TEST(suite, char_posMinWidth_zeroFlag);
+	SUITE_ADD_TEST(suite, str_posMinWidth_zeroFlag);
+	SUITE_ADD_TEST(suite, wide_str_posMinWidth_zeroFlag);
 	SUITE_ADD_TEST(suite, pointer_posMinWidth_zeroFlag);
 	SUITE_ADD_TEST(suite, pointer_valueLargerThanMinWidth_zeroFlag);
 }

--- a/ft_printf_tests/tests/62_flag_space.spec.c
+++ b/ft_printf_tests/tests/62_flag_space.spec.c
@@ -56,6 +56,42 @@ static void sFakeNullString_spaceFlag(t_test *test)
 	assert_printf("{% s}", "(null)");
 }
 
+static void sEmptyString_spaceFlag(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("{% s}", "");
+}
+
+static void test_space_C_zero(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("{% C}", 0);
+}
+
+static void CValidChar_spaceFlag(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("{% C}", L'a');
+}
+
+static void SNullString_spaceFlag(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("{% S}", NULL);
+}
+
+static void SFakeNullString_spaceFlag(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("{% S}", L"(null)");
+}
+
+static void SEmptyString_spaceFlag(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("{% S}", L"");
+}
+
 void	suite_62_flag_space(t_suite *suite)
 {
 	SUITE_ADD_TEST(suite, test_space_d_simple);
@@ -67,4 +103,10 @@ void	suite_62_flag_space(t_suite *suite)
 	SUITE_ADD_TEST(suite, cValidChar_spaceFlag);
 	SUITE_ADD_TEST(suite, sNullString_spaceFlag);
 	SUITE_ADD_TEST(suite, sFakeNullString_spaceFlag);
+	SUITE_ADD_TEST(suite, sEmptyString_spaceFlag);
+	SUITE_ADD_TEST(suite, test_space_C_zero);
+	SUITE_ADD_TEST(suite, CValidChar_spaceFlag);
+	SUITE_ADD_TEST(suite, SNullString_spaceFlag);
+	SUITE_ADD_TEST(suite, SFakeNullString_spaceFlag);
+	SUITE_ADD_TEST(suite, SEmptyString_spaceFlag);
 }

--- a/ft_printf_tests/tests/72_precision_for_sS.spec.c
+++ b/ft_printf_tests/tests/72_precision_for_sS.spec.c
@@ -20,6 +20,12 @@ static void test_precision_s_higher_precision(t_test *test)
 	assert_printf("%4.15s", "42");
 }
 
+static void test_precision_s_implicit_precision(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%4.s", "42");
+}
+
 static void test_precision_S(t_test *test)
 {
 	// test->debug = 1;
@@ -38,6 +44,12 @@ static void test_precision_S_higher_precision(t_test *test)
 	assert_printf("%4.15S", L"我是一只猫。");
 }
 
+static void test_precision_S_implicit_precision(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%4.S", L"我是一只猫。");
+}
+
 static void test_precision_S_higher_precision_ascii(t_test *test)
 {
 	// test->debug = 1;
@@ -49,8 +61,10 @@ void	suite_72_precision_for_sS(t_suite *suite)
 	SUITE_ADD_TEST(suite, test_precision_s);
 	SUITE_ADD_TEST(suite, test_precision_s_higher_min_width);
 	SUITE_ADD_TEST(suite, test_precision_s_higher_precision);
+	SUITE_ADD_TEST(suite, test_precision_s_implicit_precision);
 	SUITE_ADD_TEST(suite, test_precision_S);
 	SUITE_ADD_TEST(suite, test_precision_S_higher_min_width);
 	SUITE_ADD_TEST(suite, test_precision_S_higher_precision);
+	SUITE_ADD_TEST(suite, test_precision_S_implicit_precision);
 	SUITE_ADD_TEST(suite, test_precision_S_higher_precision_ascii);
 }


### PR DESCRIPTION
Empty argument cases were not tested for ls.
![empty_args_preview](https://cloud.githubusercontent.com/assets/2564553/5759486/8c155b20-9cce-11e4-8748-f431920e64d9.png)
Printf tests were a little too shallow in a few places.