### PR TITLE
Update 01_part2_ft_itoa.spec.c

### DIFF
--- a/libft_tests/tests/01_part2_ft_itoa.spec.c
+++ b/libft_tests/tests/01_part2_ft_itoa.spec.c
@@ -1,3 +1,4 @@
+#include <limits.h>
 #include <project.h>
 
 static void test_num1(t_test *test)
@@ -20,10 +21,35 @@ static void test_num4(t_test *test)
 	mt_assert(strcmp(ft_itoa(-2147483648), "-2147483648") == 0);
 }
 
+static void test_num5(t_test *test)
+{
+	char	s[16];
+	char	*p;
+	int		n;
+	int		ret;
+
+	n = INT_MIN;
+	while (n < 0)
+	{
+		sprintf(s, "%d", n);
+		p = ft_itoa(n);
+		ret = strcmp(s, p);
+		free(p);
+		if (ret)
+		{
+			mt_assert(0);
+			return ;
+		}
+		n += 777;
+	}
+	mt_assert(1);
+}
+
 void	suite_01_part2_ft_itoa(t_suite *suite)
 {
 	SUITE_ADD_TEST(suite, test_num1);
 	SUITE_ADD_TEST(suite, test_num2);
 	SUITE_ADD_TEST(suite, test_num3);
 	SUITE_ADD_TEST(suite, test_num4);
+	SUITE_ADD_TEST(suite, test_num5);
 }


### PR DESCRIPTION
Tente de free() le retour de ft_itoa() pour s'assurer que malloc() a été utilisé.