### PR TITLE
[FT_PRINTF] 4 more test usefull . Update 72_precision_for_sS.spec.c

### DIFF
--- a/ft_printf_tests/tests/72_precision_for_sS.spec.c
+++ b/ft_printf_tests/tests/72_precision_for_sS.spec.c
@@ -20,10 +20,34 @@ static void test_precision_s_higher_min_width(t_test *test)
 	assert_printf("%15.4s", "42");
 }
 
+static void test_precision_s_higher_min_width_len_between_width_prec(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%15.4s", "I am 42");
+}
+
+static void test_precision_s_higher_min_width_len_higher_width(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%15.4s", "42 is the answer");
+}
+
 static void test_precision_s_higher_precision(t_test *test)
 {
 	// test->debug = 1;
 	assert_printf("%4.15s", "42");
+}
+
+static void test_precision_s_higher_precision_len_between_width_prec(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%4.15s", "I am 42");
+}
+
+static void test_precision_s_higher_precision_len_higher_width(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%4.15s", "42 is the answer");
 }
 
 static void test_precision_s_implicit_precision(t_test *test)
@@ -67,7 +91,11 @@ void	suite_72_precision_for_sS(t_suite *suite)
 	SUITE_ADD_TEST(suite, test_precision_s);
 	SUITE_ADD_TEST(suite, test_precision_s_prec_smaller_than_s_len);
 	SUITE_ADD_TEST(suite, test_precision_s_higher_min_width);
+	SUITE_ADD_TEST(suite, test_precision_s_higher_min_width_len_between_width_prec);
+	SUITE_ADD_TEST(suite, test_precision_s_higher_min_width_len_higher_width);
 	SUITE_ADD_TEST(suite, test_precision_s_higher_precision);
+	SUITE_ADD_TEST(suite, test_precision_s_higher_precision_len_between_width_prec);
+	SUITE_ADD_TEST(suite, test_precision_s_higher_precision_len_higher_width);
 	SUITE_ADD_TEST(suite, test_precision_s_implicit_precision);
 	SUITE_ADD_TEST(suite, test_precision_S);
 	SUITE_ADD_TEST(suite, test_precision_S_higher_min_width);


### PR DESCRIPTION
les changements concernent un peu le meme delire que la taille de la chaine superieur a le precision.
cette fois c'est :
test_precision_s_higher_min_width_len_between_width_prec
test_precision_s_higher_min_width_len_higher_width
test_precision_s_higher_precision_len_between_width_prec
test_precision_s_higher_precision_len_higher_width

les noms parlent d'eux meme : tu as fait des tests avec la len inferieur a la precision.
j'ai rajouté une len entre les deux, et une len superieur.

perso j'était tout en vert, et ces 4 la ne passe pas :D
donc utile a mon avis.

par contre il y a surement le meme delire pour le grand S, mais de suite, j'ai pas le courage, je verrai demain ou te laisse le faire si ta le temps.
bye
