### PR TITLE
[FT_PRINTF] environ + 14 tests / Update 70_precision_for_diu.spec.c

### DIFF
--- a/ft_printf_tests/tests/70_precision_for_diu.spec.c
+++ b/ft_printf_tests/tests/70_precision_for_diu.spec.c
@@ -190,6 +190,9 @@ void	suite_70_precision_for_diu(t_suite *suite)
 	SUITE_ADD_TEST(suite, test_precision_d_higher_min_width);
 	SUITE_ADD_TEST(suite, test_precision_d_higher_min_width_len_between_width_prec);
 	SUITE_ADD_TEST(suite, test_precision_d_higher_min_width_len_higher_width);
+	SUITE_ADD_TEST(suite, test_precision_d_higher_min_width_neg);
+	SUITE_ADD_TEST(suite, test_precision_d_higher_min_width_len_between_width_prec_neg);
+	SUITE_ADD_TEST(suite, test_precision_d_higher_min_width_len_higher_width_neg);
 	SUITE_ADD_TEST(suite, test_precision_d_higher_precision);
 	SUITE_ADD_TEST(suite, test_precision_d_higher_precision_len_between_width_prec);
 	SUITE_ADD_TEST(suite, test_precision_d_higher_precision_len_higher_prec);
@@ -209,6 +212,6 @@ void	suite_70_precision_for_diu(t_suite *suite)
 	SUITE_ADD_TEST(suite, test_precision_u_higher_min_width_len_higher_width);
 	SUITE_ADD_TEST(suite, test_precision_u_higher_precision);
 	SUITE_ADD_TEST(suite, test_precision_u_higher_precision_len_between_width_prec);
-	SUITE_ADD_TEST(suite, test_precision_u_higher_precision_len_higher_width);
+	SUITE_ADD_TEST(suite, test_precision_u_higher_precision_len_higher_prec);
 	SUITE_ADD_TEST(suite, test_precision_u_zero_value);
 }

--- a/ft_printf_tests/tests/70_precision_for_diu.spec.c
+++ b/ft_printf_tests/tests/70_precision_for_diu.spec.c
@@ -8,16 +8,88 @@ static void test_precision_d(t_test *test)
 	assert_printf("%.4d", 42);
 }
 
+static void test_precision_d_len_higher_prec(t_test *test)
+{
+	// test->debug = 1;
+    assert_printf("%.4d", 424242);
+}
+
+static void test_precision_d_len_higher_prec_neg(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%.4d", -424242);
+}
+
 static void test_precision_d_higher_min_width(t_test *test)
 {
 	// test->debug = 1;
 	assert_printf("%15.4d", 42);
 }
 
+static void test_precision_d_higher_min_width_len_between_width_prec(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%15.4d", 424242);
+}
+
+static void test_precision_d_higher_min_width_len_higher_width(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%8.4d", 424242424);
+}
+
+static void test_precision_d_higher_min_width_neg(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%15.4d", -42);
+}
+
+static void test_precision_d_higher_min_width_len_between_width_prec_neg(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%15.4d", -424242);
+}
+
+static void test_precision_d_higher_min_width_len_higher_width_neg(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%8.4d", -424242424);
+}
+
 static void test_precision_d_higher_precision(t_test *test)
 {
 	// test->debug = 1;
 	assert_printf("%4.15d", 42);
+}
+
+static void test_precision_d_higher_precision_len_between_width_prec(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%4.15d", 424242);
+}
+
+static void test_precision_d_higher_precision_len_higher_prec(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%4.8d", 424242424);
+}
+
+static void test_precision_d_higher_precision_neg(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%4.15d", -42);
+}
+
+static void test_precision_d_higher_precision_len_between_width_prec_neg(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%4.15d", -424242);
+}
+
+static void test_precision_d_higher_precision_len_higher_prec_neg(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%4.8d", -424242424);
 }
 
 static void test_precision_d_zero_value(t_test *test)
@@ -62,16 +134,46 @@ static void test_precision_u(t_test *test)
 	assert_printf("%.4u", 42);
 }
 
+static void test_precision_u_len_higher_prec(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%.4u", 424242);
+}
+
 static void test_precision_u_higher_min_width(t_test *test)
 {
 	// test->debug = 1;
 	assert_printf("%15.4u", 42);
 }
 
+static void test_precision_u_higher_min_width_len_between_width_prec(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%15.4u", 424242);
+}
+
+static void test_precision_u_higher_min_width_len_higher_width(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%8.4u", 424242424);
+}
+
 static void test_precision_u_higher_precision(t_test *test)
 {
 	// test->debug = 1;
 	assert_printf("%4.15u", 42);
+}
+
+static void test_precision_u_higher_precision_len_between_width_prec(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%4.15u", 424242);
+}
+
+static void test_precision_u_higher_precision_len_higher_prec(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%4.8u", 424242424);
 }
 
 static void test_precision_u_zero_value(t_test *test)
@@ -83,8 +185,17 @@ static void test_precision_u_zero_value(t_test *test)
 void	suite_70_precision_for_diu(t_suite *suite)
 {
 	SUITE_ADD_TEST(suite, test_precision_d);
+	SUITE_ADD_TEST(suite, test_precision_d_len_higher_prec);
+	SUITE_ADD_TEST(suite, test_precision_d_len_higher_prec_neg);
 	SUITE_ADD_TEST(suite, test_precision_d_higher_min_width);
+	SUITE_ADD_TEST(suite, test_precision_d_higher_min_width_len_between_width_prec);
+	SUITE_ADD_TEST(suite, test_precision_d_higher_min_width_len_higher_width);
 	SUITE_ADD_TEST(suite, test_precision_d_higher_precision);
+	SUITE_ADD_TEST(suite, test_precision_d_higher_precision_len_between_width_prec);
+	SUITE_ADD_TEST(suite, test_precision_d_higher_precision_len_higher_prec);
+	SUITE_ADD_TEST(suite, test_precision_d_higher_precision_neg);
+	SUITE_ADD_TEST(suite, test_precision_d_higher_precision_len_between_width_prec_neg);
+	SUITE_ADD_TEST(suite, test_precision_d_higher_precision_len_higher_prec_neg);
 	SUITE_ADD_TEST(suite, test_precision_d_zero_value);
 	SUITE_ADD_TEST(suite, test_precision_d_negative_value);
 	SUITE_ADD_TEST(suite, test_precision_i);
@@ -92,7 +203,12 @@ void	suite_70_precision_for_diu(t_suite *suite)
 	SUITE_ADD_TEST(suite, test_precision_i_higher_precision);
 	SUITE_ADD_TEST(suite, test_precision_i_zero_value);
 	SUITE_ADD_TEST(suite, test_precision_u);
+	SUITE_ADD_TEST(suite, test_precision_u_len_higher_prec);
 	SUITE_ADD_TEST(suite, test_precision_u_higher_min_width);
+	SUITE_ADD_TEST(suite, test_precision_u_higher_min_width_len_between_width_prec);
+	SUITE_ADD_TEST(suite, test_precision_u_higher_min_width_len_higher_width);
 	SUITE_ADD_TEST(suite, test_precision_u_higher_precision);
+	SUITE_ADD_TEST(suite, test_precision_u_higher_precision_len_between_width_prec);
+	SUITE_ADD_TEST(suite, test_precision_u_higher_precision_len_higher_width);
 	SUITE_ADD_TEST(suite, test_precision_u_zero_value);
 }

--- a/ft_printf_tests/tests/71_precision_for_oOxX.spec.c
+++ b/ft_printf_tests/tests/71_precision_for_oOxX.spec.c
@@ -8,16 +8,46 @@ static void test_precision_o(t_test *test)
 	assert_printf("%.4o", 42);
 }
 
+static void test_precision_o_len_higher_prec(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%.4o", 424242);
+}
+
 static void test_precision_o_higher_min_width(t_test *test)
 {
 	// test->debug = 1;
 	assert_printf("%15.4o", 42);
 }
 
+static void test_precision_o_higher_min_width_len_between_width_prec(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%15.4o", 424242);
+}
+
+static void test_precision_o_higher_min_width_len_higher_width(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%8.4o", 424242424);
+}
+
 static void test_precision_o_higher_precision(t_test *test)
 {
 	// test->debug = 1;
 	assert_printf("%4.15o", 42);
+}
+
+static void test_precision_o_higher_precision_len_between_width_prec(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%4.15o", 424242);
+}
+
+static void test_precision_o_higher_precision_len_higher_prec(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%4.8o", 424242424);
 }
 
 static void test_precision_o_zero_value(t_test *test)
@@ -56,16 +86,46 @@ static void test_precision_x(t_test *test)
 	assert_printf("%.4x", 42);
 }
 
+static void test_precision_x_len_higher_prec(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%.4x", 424242);
+}
+
 static void test_precision_x_higher_min_width(t_test *test)
 {
 	// test->debug = 1;
 	assert_printf("%15.4x", 42);
 }
 
+static void test_precision_x_higher_min_width_len_between_width_prec(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%15.4x", 424242);
+}
+
+static void test_precision_x_higher_min_width_len_higher_width(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%8.4x", 424242424);
+}
+
 static void test_precision_x_higher_precision(t_test *test)
 {
 	// test->debug = 1;
 	assert_printf("%4.15x", 42);
+}
+
+static void test_precision_x_higher_precision_len_between_width_prec(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%4.15x", 42424242);
+}
+
+static void test_precision_x_higher_precision_len_higher_prec(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%4.8x", 424242424);
 }
 
 static void test_precision_x_zero_value(t_test *test)
@@ -80,16 +140,46 @@ static void test_precision_x_up(t_test *test)
 	assert_printf("%.4X", 42);
 }
 
+static void test_precision_x_up_len_higher_prec(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%.4X", 424242);
+}
+
 static void test_precision_x_up_higher_min_width(t_test *test)
 {
 	// test->debug = 1;
 	assert_printf("%15.4X", 42);
 }
 
+static void test_precision_x_up_higher_min_width_len_between_width_prec(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%15.4X", 424242);
+}
+
+static void test_precision_x_up_higher_min_width_len_higher_width(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%8.4X", 424242424);
+}
+
 static void test_precision_x_up_higher_precision(t_test *test)
 {
 	// test->debug = 1;
 	assert_printf("%4.15X", 42);
+}
+
+static void test_precision_x_up_higher_precision_len_between_width_prec(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%4.15X", 424242);
+}
+
+static void test_precision_x_up_higher_precision_len_higher_prec(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%4.8X", 424242424);
 }
 
 static void test_precision_x_up_zero_value(t_test *test)
@@ -102,19 +192,34 @@ static void test_precision_x_up_zero_value(t_test *test)
 void	suite_71_precision_for_oOxX(t_suite *suite)
 {
 	SUITE_ADD_TEST(suite, test_precision_o);
+	SUITE_ADD_TEST(suite, test_precision_o_len_higher_prec);
 	SUITE_ADD_TEST(suite, test_precision_o_higher_min_width);
+	SUITE_ADD_TEST(suite, test_precision_o_higher_min_width_len_between_width_prec);
+	SUITE_ADD_TEST(suite, test_precision_o_higher_min_width_len_higher_width);
 	SUITE_ADD_TEST(suite, test_precision_o_higher_precision);
+	SUITE_ADD_TEST(suite, test_precision_o_higher_precision_len_between_width_prec);
+	SUITE_ADD_TEST(suite, test_precision_o_higher_precision_len_higher_prec);
 	SUITE_ADD_TEST(suite, test_precision_o_zero_value);
 	SUITE_ADD_TEST(suite, test_precision_o_up);
 	SUITE_ADD_TEST(suite, test_precision_o_up_higher_min_width);
 	SUITE_ADD_TEST(suite, test_precision_o_up_higher_precision);
 	SUITE_ADD_TEST(suite, test_precision_o_up_zero_value);
 	SUITE_ADD_TEST(suite, test_precision_x);
+	SUITE_ADD_TEST(suite, test_precision_x_len_higher_prec);
 	SUITE_ADD_TEST(suite, test_precision_x_higher_min_width);
+	SUITE_ADD_TEST(suite, test_precision_x_higher_min_width_len_between_width_prec);
+	SUITE_ADD_TEST(suite, test_precision_x_higher_min_width_len_higher_width);
 	SUITE_ADD_TEST(suite, test_precision_x_higher_precision);
+	SUITE_ADD_TEST(suite, test_precision_x_higher_precision_len_between_width_prec);
+	SUITE_ADD_TEST(suite, test_precision_x_higher_precision_len_higher_prec);
 	SUITE_ADD_TEST(suite, test_precision_x_zero_value);
 	SUITE_ADD_TEST(suite, test_precision_x_up);
+	SUITE_ADD_TEST(suite, test_precision_x_up_len_higher_prec);
 	SUITE_ADD_TEST(suite, test_precision_x_up_higher_min_width);
+	SUITE_ADD_TEST(suite, test_precision_x_up_higher_min_width_len_between_width_prec);
+	SUITE_ADD_TEST(suite, test_precision_x_up_higher_min_width_len_higher_width);
 	SUITE_ADD_TEST(suite, test_precision_x_up_higher_precision);
+	SUITE_ADD_TEST(suite, test_precision_x_up_higher_precision_len_between_width_prec);
+	SUITE_ADD_TEST(suite, test_precision_x_up_higher_precision_len_higher_prec);
 	SUITE_ADD_TEST(suite, test_precision_x_up_zero_value);
 }

--- a/ft_printf_tests/tests/74_precision_for_p.spec.c
+++ b/ft_printf_tests/tests/74_precision_for_p.spec.c
@@ -14,8 +14,22 @@ static void pNullPointer_3Precision(t_test *test)
 	assert_printf("%.5p", 0);
 }
 
+static void Pointer_Precision_width_len_between_width_prec(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%9.2p", 1234);
+}
+
+static void Pointer_Precision_width_len_higher_width(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%9.2p", 1234567);
+}
+
 void	suite_74_precision_for_p(t_suite *suite)
 {
 	SUITE_ADD_TEST(suite, pNullPointer_zeroPrecision);
 	SUITE_ADD_TEST(suite, pNullPointer_3Precision);
+	SUITE_ADD_TEST(suite, Pointer_Precision_width_len_between_width_prec);
+	SUITE_ADD_TEST(suite, Pointer_Precision_width_len_higher_width);
 }

--- a/ft_printf_tests/tests/74_precision_for_p.spec.c
+++ b/ft_printf_tests/tests/74_precision_for_p.spec.c
@@ -26,10 +26,24 @@ static void Pointer_Precision_width_len_higher_width(t_test *test)
 	assert_printf("%9.2p", 1234567);
 }
 
+static void Pointer_Precision_width_min_len_between_width_prec(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%2.9p", 1234);
+}
+
+static void Pointer_Precision_width_min_len_higher_prec(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%2.9p", 1234567);
+}
+
 void	suite_74_precision_for_p(t_suite *suite)
 {
 	SUITE_ADD_TEST(suite, pNullPointer_zeroPrecision);
 	SUITE_ADD_TEST(suite, pNullPointer_3Precision);
 	SUITE_ADD_TEST(suite, Pointer_Precision_width_len_between_width_prec);
 	SUITE_ADD_TEST(suite, Pointer_Precision_width_len_higher_width);
+	SUITE_ADD_TEST(suite, Pointer_Precision_width_min_len_between_width_prec);
+	SUITE_ADD_TEST(suite, Pointer_Precision_width_min_len_higher_prec);
 }


### PR DESCRIPTION
edit: cf commit

meme principe que ma modif sur le s.

g rajouter, pour d et u. et egalement pour p (2 test) => je debut sur git, mais on m'explike en fai, du coup pour ce merge la, c un pe le bordel je pense, mais pour les prochain, ca sera nikel, me suis créé une branche dev, et pr le prochain pull requet je penserai a faire un git pull origin master avant ... bref

g pas rajouter des test pour le i, car theoriquement c la meme fonction qui gere le d et le i, donc si le d passe, le i aussi .....

donc, test pour mettre la len du chiffre entre prec et width, superieur a width (ou prec (selon le plus grand))
- rajout des chiffres negatif tjs sur le meme principe (len de la taille du chiffre superieur, entre, etc ...)

comme d'habitude, mon parseur n'etant pas parfait, tous tes test etait verts (tu le savais deja), avec ces nouveaux test, j'ai plein de F. :D (9 pour etre precis) (souvent c le retour qd neg, mais pas tjs, osef)

je rajouterai surement des tests, pour oOxX plus tard
(de plus tjs en theorie, si les tests passent pr le u, le o et x devraient suivre, car la fonction qui les geres devraient etre les memes .....

au pire suffi de rajouter les tests present dans le 70_diu, et de les mettre dans le fichier oOxX.

see u.
