### PR TITLE
Python3 support

### DIFF
--- a/src/moulitest
+++ b/src/moulitest
@@ -1,6 +1,9 @@
 #!/usr/bin/python
 
-import ConfigParser
+try:
+	import ConfigParser
+except:
+	import configparser as ConfigParser
 import os
 
 def get_mt_dir():


### PR DESCRIPTION
In python3, ConfigParser module was renamed to configparser. This little patch makes the script compatible with both versions of python.