### PR TITLE
Suppression du test unsetenv avec une variable inexistante

### DIFF
--- a/ft_sh_tests/tests/sh1/sh1_04_cmd_unsetenv.spec.c
+++ b/ft_sh_tests/tests/sh1/sh1_04_cmd_unsetenv.spec.c
@@ -8,12 +8,6 @@ static void simple_unsetenv_test(t_test *test)
 		"grep '^aaa='");
 }
 
-static void test_not_existing_key(t_test *test)
-{
-	// test->debug = 1;
-	mt_assert_sh_stderr_is_empty(test, "unsetenv keydoesnotexist\nexit\n");
-}
-
 static void unset_multiple_envs(t_test *test)
 {
 	// test->debug = 1;
@@ -25,6 +19,5 @@ static void unset_multiple_envs(t_test *test)
 void	suite_sh1_04_cmd_unsetenv(t_suite *suite)
 {
 	SUITE_ADD_TEST(suite, simple_unsetenv_test);
-	SUITE_ADD_TEST(suite, test_not_existing_key);
 	SUITE_ADD_TEST(suite, unset_multiple_envs);
 }


### PR DESCRIPTION
Ce test pose probleme dans le cas de l'affichage d'un message d'erreur,
ce qui est plus propre que ne rien afficher.
