### PR TITLE
unitest stack_to_ram

### DIFF
--- a/libft_tests/tests/00_part1_ft_strlen.spec.c
+++ b/libft_tests/tests/00_part1_ft_strlen.spec.c
@@ -1,4 +1,5 @@
 #include <project.h>
+#include <stdlib.h>
 
 #define mt_test_strlen(test_name, tested_str) \
 	static void unit## test_name(t_test *test) \
@@ -13,11 +14,12 @@ mt_test_strlen(test3, "aaa\0aaa");
 static void test_10_million_chars_string(t_test *test)
 {
 	int test_len = 10 * 1000 * 1000;
-	char str[test_len];
+	char *str = malloc(sizeof(char) * test_len);;
 
 	memset(str, 'a', test_len);
 	str[test_len - 1] = '\0';
 	mt_assert(ft_strlen(str) == strlen(str));
+	free(str);
 }
 void	suite_00_part1_ft_strlen(t_suite *suite)
 {


### PR DESCRIPTION
Le test crash facilement sur des petis pc. Avec malloc les données sont stockées dans la ram. La qualité du test n'est pas modifiée 
