### PR TITLE
"Return Value : A value different from zero if indeed c is a printable character"

### DIFF
--- a/libft_tests/tests/00_part1_ft_isprint.spec.c
+++ b/libft_tests/tests/00_part1_ft_isprint.spec.c
@@ -3,7 +3,7 @@
 #define mt_test_isprint(test_name, tested_char)								\
 	static void test_## test_name(t_test *test)								\
 	{																		\
-		mt_assert(ft_isprint(tested_char) == isprint(tested_char));			\
+		mt_assert((ft_isprint(tested_char) && 1) == (isprint(tested_char) && 1));			\
 	}
 
 mt_test_isprint(num1, 'a');


### PR DESCRIPTION
As the manual says so, the return value is nonzero if it works, so as a fix, this addition gets the boolean result back to 1 or 0 (with the && 1).
I made this pull request after having this issue : https://github.com/yyang42/moulitest/issues/15
