### PR TITLE
first_test_corr.c

### DIFF
--- a/libft_tests/tests/00_part1_ft_memcmp.spec.c
+++ b/libft_tests/tests/00_part1_ft_memcmp.spec.c
@@ -2,7 +2,7 @@
 
 static void unittest1(t_test *test)
 {
-	mt_assert(ft_memcmp(ft_strdup("ab\0ab"), ft_strdup("ab\0ab"), 5) == 0);
+	mt_assert(ft_memcmp(ft_strdup("ab\0ab"), ft_strdup("ab\0ab"), 3) == 0);
 
 }
 


### PR DESCRIPTION
Erreur dans le test 1, qui ne correspond pas au comportement de memcmp
ft_memcmp(ft_strdup("ab\0ab"), ft_strdup("ab\0ab"), 3) == 0);
