### PR TITLE
overflow for numbers

### DIFF
--- a/ft_printf_tests/tests/03_conv_d.spec.c
+++ b/ft_printf_tests/tests/03_conv_d.spec.c
@@ -45,6 +45,18 @@ static void test_int_min(t_test *test)
 	assert_printf("%d", INT_MIN);
 }
 
+static void test_int_max_plus(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%d", INT_MAX + 1);
+}
+
+static void test_int_min_less(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%d", INT_MIN - 1);
+}
+
 void	suite_03_conv_d(t_suite *suite)
 {
 	SUITE_ADD_TEST(suite, test_digit);
@@ -54,4 +66,6 @@ void	suite_03_conv_d(t_suite *suite)
 	SUITE_ADD_TEST(suite, test_many_digits_width_strings);
 	SUITE_ADD_TEST(suite, test_int_max);
 	SUITE_ADD_TEST(suite, test_int_min);
+	SUITE_ADD_TEST(suite, test_int_max_plus);
+	SUITE_ADD_TEST(suite, test_int_min_less);
 }

--- a/ft_printf_tests/tests/08_conv_D.spec.c
+++ b/ft_printf_tests/tests/08_conv_D.spec.c
@@ -28,10 +28,24 @@ static void test_with_strings(t_test *test)
 	assert_printf("Coucou les %D!", 42);
 }
 
+static void test_long_max_plus(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%D", LONG_MAX + 1);
+}
+
+static void test_long_min_less(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%D", LONG_MIN - 1);
+}
+
 void	suite_08_conv_D(t_suite *suite)
 {
 	SUITE_ADD_TEST(suite, test_simple);
 	SUITE_ADD_TEST(suite, test_long_max);
 	SUITE_ADD_TEST(suite, test_long_min);
 	SUITE_ADD_TEST(suite, test_with_strings);
+	SUITE_ADD_TEST(suite, test_long_max_plus);
+	SUITE_ADD_TEST(suite, test_long_min_less);
 }

--- a/ft_printf_tests/tests/09_conv_i.spec.c
+++ b/ft_printf_tests/tests/09_conv_i.spec.c
@@ -1,4 +1,5 @@
 #include <project.h>
+#include <limits.h>
 
 static void test_digit(t_test *test)
 {
@@ -32,6 +33,30 @@ static void test_many_digits_width_strings(t_test *test)
 		1, -2, 3);
 }
 
+static void test_int_max(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%i", INT_MAX);
+}
+
+static void test_int_min(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%i", INT_MIN);
+}
+
+static void test_int_max_plus(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%i", INT_MAX + 1);
+}
+
+static void test_int_min_less(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%i", INT_MIN - 1);
+}
+
 void	suite_09_conv_i(t_suite *suite)
 {
 	SUITE_ADD_TEST(suite, test_digit);
@@ -39,4 +64,8 @@ void	suite_09_conv_i(t_suite *suite)
 	SUITE_ADD_TEST(suite, test_digit_with_strings);
 	SUITE_ADD_TEST(suite, test_many_digits);
 	SUITE_ADD_TEST(suite, test_many_digits_width_strings);
+	SUITE_ADD_TEST(suite, test_int_max);
+	SUITE_ADD_TEST(suite, test_int_min);
+	SUITE_ADD_TEST(suite, test_int_max_plus);
+	SUITE_ADD_TEST(suite, test_int_min_less);
 }

--- a/ft_printf_tests/tests/10_conv_o.spec.c
+++ b/ft_printf_tests/tests/10_conv_o.spec.c
@@ -26,10 +26,17 @@ static void test_many_octals_with_strings(t_test *test)
 		0, 55555, 100000);
 }
 
+static void test_octal_negative(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%o", -1);
+}
+
 void	suite_10_conv_o(t_suite *suite)
 {
 	SUITE_ADD_TEST(suite, test_simple);
 	SUITE_ADD_TEST(suite, test_octal_with_strings);
 	SUITE_ADD_TEST(suite, test_many_octals);
 	SUITE_ADD_TEST(suite, test_many_octals_with_strings);
+	SUITE_ADD_TEST(suite, test_octal_negative);
 }

--- a/ft_printf_tests/tests/11_conv_O.spec.c
+++ b/ft_printf_tests/tests/11_conv_O.spec.c
@@ -33,6 +33,12 @@ static void test_octal_long_max(t_test *test)
 	assert_printf("%O", LONG_MAX);
 }
 
+static void test_octal_negative(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%O", -1);
+}
+
 void	suite_11_conv_O(t_suite *suite)
 {
 	SUITE_ADD_TEST(suite, test_simple);
@@ -40,4 +46,5 @@ void	suite_11_conv_O(t_suite *suite)
 	SUITE_ADD_TEST(suite, test_many_long_octals);
 	SUITE_ADD_TEST(suite, test_many_long_octals_with_strings);
 	SUITE_ADD_TEST(suite, test_octal_long_max);
+	SUITE_ADD_TEST(suite, test_octal_negative);
 }

--- a/ft_printf_tests/tests/12_conv_u.spec.c
+++ b/ft_printf_tests/tests/12_conv_u.spec.c
@@ -33,6 +33,12 @@ static void test_uints_max(t_test *test)
 	assert_printf("%u", UINT_MAX);
 }
 
+static void test_uint_negative(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%u", -1);
+}
+
 void	suite_12_conv_u(t_suite *suite)
 {
 	SUITE_ADD_TEST(suite, test_simple);
@@ -40,4 +46,5 @@ void	suite_12_conv_u(t_suite *suite)
 	SUITE_ADD_TEST(suite, test_many_uints);
 	SUITE_ADD_TEST(suite, test_many_uints_with_strings);
 	SUITE_ADD_TEST(suite, test_uints_max);
+	SUITE_ADD_TEST(suite, test_uint_negative);
 }

--- a/ft_printf_tests/tests/13_conv_U.spec.c
+++ b/ft_printf_tests/tests/13_conv_U.spec.c
@@ -19,9 +19,16 @@ static void test_ulong_max(t_test *test)
 	assert_printf("%U", ULONG_MAX);
 }
 
+static void test_ulong_negative(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%U", -1);
+}
+
 void	suite_13_conv_U(t_suite *suite)
 {
 	SUITE_ADD_TEST(suite, test_simple);
 	SUITE_ADD_TEST(suite, test_ulong_max_half);
 	SUITE_ADD_TEST(suite, test_ulong_max);
+	SUITE_ADD_TEST(suite, test_ulong_negative);
 }

--- a/ft_printf_tests/tests/14_conv_x.spec.c
+++ b/ft_printf_tests/tests/14_conv_x.spec.c
@@ -33,6 +33,12 @@ static void test_uint_max(t_test *test)
 	assert_printf("%x, %x", 0, UINT_MAX);
 }
 
+static void test_uint_negative(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%x", -1);
+}
+
 void	suite_14_conv_x(t_suite *suite)
 {
 	SUITE_ADD_TEST(suite, test_simple);
@@ -40,4 +46,5 @@ void	suite_14_conv_x(t_suite *suite)
 	SUITE_ADD_TEST(suite, test_many_hexs);
 	SUITE_ADD_TEST(suite, test_many_hexs_with_strings);
 	SUITE_ADD_TEST(suite, test_uint_max);
+	SUITE_ADD_TEST(suite, test_uint_negative);
 }

--- a/ft_printf_tests/tests/15_conv_X.spec.c
+++ b/ft_printf_tests/tests/15_conv_X.spec.c
@@ -33,6 +33,12 @@ static void test_uint_max(t_test *test)
 	assert_printf("%X, %X", 0, UINT_MAX);
 }
 
+static void test_uint_negative(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%X", -1);
+}
+
 void	suite_15_conv_X(t_suite *suite)
 {
 	SUITE_ADD_TEST(suite, test_simple);
@@ -40,4 +46,5 @@ void	suite_15_conv_X(t_suite *suite)
 	SUITE_ADD_TEST(suite, test_many_hexs);
 	SUITE_ADD_TEST(suite, test_many_hexs_with_strings);
 	SUITE_ADD_TEST(suite, test_uint_max);
+	SUITE_ADD_TEST(suite, test_uint_negative);
 }

--- a/ft_printf_tests/tests/40_length_modif_l.spec.c
+++ b/ft_printf_tests/tests/40_length_modif_l.spec.c
@@ -32,6 +32,12 @@ static void test_ld_long_min(t_test *test)
 	assert_printf("%ld", LONG_MIN);
 }
 
+static void test_ld_long_max_plus(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%ld", LONG_MAX + 1);
+}
+
 static void test_li_simple(t_test *test)
 {
 	// test->debug = 1;
@@ -62,10 +68,22 @@ static void test_li_long_min(t_test *test)
 	assert_printf("%li", LONG_MIN);
 }
 
+static void test_li_long_max_plus(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%li", LONG_MAX + 1);
+}
+
 static void test_lu_long_unsigned_max(t_test *test)
 {
 	// test->debug = 1;
 	assert_printf("%lu, %lu", 0, ULONG_MAX);
+}
+
+static void test_lu_long_unsigned_max_plus(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%lu, %lu", 0, ULONG_MAX + 1);
 }
 
 static void test_lo_long_unsigned_max(t_test *test)
@@ -122,14 +140,17 @@ void	suite_40_length_modif_l(t_suite *suite)
 	SUITE_ADD_TEST(suite, test_ld_int_min_minus);
 	SUITE_ADD_TEST(suite, test_ld_long_max);
 	SUITE_ADD_TEST(suite, test_ld_long_min);
+	SUITE_ADD_TEST(suite, test_ld_long_max_plus);
 
 	SUITE_ADD_TEST(suite, test_li_simple);
 	SUITE_ADD_TEST(suite, test_li_int_max_plus);
 	SUITE_ADD_TEST(suite, test_li_int_min_minus);
 	SUITE_ADD_TEST(suite, test_li_long_max);
 	SUITE_ADD_TEST(suite, test_li_long_min);
+	SUITE_ADD_TEST(suite, test_li_long_max_plus);
 
 	SUITE_ADD_TEST(suite, test_lu_long_unsigned_max);
+	SUITE_ADD_TEST(suite, test_lu_long_unsigned_max_plus);
 	SUITE_ADD_TEST(suite, test_lo_long_unsigned_max);
 	SUITE_ADD_TEST(suite, test_lx_long_unsigned_max);
 	SUITE_ADD_TEST(suite, test_lX_long_unsigned_max);

--- a/ft_printf_tests/tests/41_length_modif_ll.spec.c
+++ b/ft_printf_tests/tests/41_length_modif_ll.spec.c
@@ -14,6 +14,12 @@ static void test_lld_llong_max(t_test *test)
 	assert_printf("%lld", LLONG_MAX);
 }
 
+static void test_lld_llong_max_plus(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%lld", LLONG_MAX + 1);
+}
+
 static void test_lld_llong_min(t_test *test)
 {
 	// test->debug = 1;
@@ -30,6 +36,12 @@ static void test_lli_llong_max(t_test *test)
 {
 	// test->debug = 1;
 	assert_printf("%lli", LLONG_MAX);
+}
+
+static void test_lli_llong_max_plus(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%lli", LLONG_MAX + 1);
 }
 
 static void test_lli_llong_min(t_test *test)
@@ -62,6 +74,30 @@ static void test_llX_unsign_long_long_max(t_test *test)
 	assert_printf("%llX, %llX", 0, ULLONG_MAX);
 }
 
+static void test_llu_unsign_long_long_max_plus(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%llu", ULLONG_MAX + 1);
+}
+
+static void test_llo_unsign_long_long_max_plus(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%llo", ULLONG_MAX + 1);
+}
+
+static void test_llx_unsign_long_long_max_plus(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%llx", ULLONG_MAX + 1);
+}
+
+static void test_llX_unsign_long_long_max_plus(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%llX", ULLONG_MAX + 1);
+}
+
 static void test_err_llo_up_max(t_test *test)
 {
 	// test->debug = 1;
@@ -83,16 +119,23 @@ void	suite_41_length_modif_ll(t_suite *suite)
 {
 	SUITE_ADD_TEST(suite, test_lld_simple);
 	SUITE_ADD_TEST(suite, test_lld_llong_max);
+	SUITE_ADD_TEST(suite, test_lld_llong_max_plus);
 	SUITE_ADD_TEST(suite, test_lld_llong_min);
 
 	SUITE_ADD_TEST(suite, test_lli_simple);
 	SUITE_ADD_TEST(suite, test_lli_llong_max);
+	SUITE_ADD_TEST(suite, test_lli_llong_max_plus);
 	SUITE_ADD_TEST(suite, test_lli_llong_min);
 
 	SUITE_ADD_TEST(suite, test_llu_unsign_long_long_max);
 	SUITE_ADD_TEST(suite, test_llo_unsign_long_long_max);
 	SUITE_ADD_TEST(suite, test_llx_unsign_long_long_max);
 	SUITE_ADD_TEST(suite, test_llX_unsign_long_long_max);
+
+	SUITE_ADD_TEST(suite, test_llu_unsign_long_long_max_plus);
+	SUITE_ADD_TEST(suite, test_llo_unsign_long_long_max_plus);
+	SUITE_ADD_TEST(suite, test_llx_unsign_long_long_max_plus);
+	SUITE_ADD_TEST(suite, test_llX_unsign_long_long_max_plus);
 
 	SUITE_ADD_TEST(suite, test_err_llo_up_max);
 	SUITE_ADD_TEST(suite, test_err_llu_up_max);

--- a/ft_printf_tests/tests/42_length_modif_h.spec.c
+++ b/ft_printf_tests/tests/42_length_modif_h.spec.c
@@ -14,6 +14,12 @@ static void test_hd_max(t_test *test)
 	assert_printf("%hd", SHRT_MAX);
 }
 
+static void test_hd_max_plus(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%hd", SHRT_MAX + 1);
+}
+
 static void test_hd_min(t_test *test)
 {
 	// test->debug = 1;
@@ -32,6 +38,12 @@ static void test_hi_max(t_test *test)
 	assert_printf("%hi", SHRT_MAX);
 }
 
+static void test_hi_max_plus(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%hi", SHRT_MAX + 1);
+}
+
 static void test_hi_min(t_test *test)
 {
 	// test->debug = 1;
@@ -42,6 +54,12 @@ static void test_hu_max(t_test *test)
 {
 	// test->debug = 1;
 	assert_printf("%hu, %hu", 0, USHRT_MAX);
+}
+
+static void test_hu_max_plus(t_test *test)
+{
+	// test->debug = 1;
+	assert_printf("%hu, %hu", 0, USHRT_MAX + 1);
 }
 
 static void test_ho_max(t_test *test)
@@ -83,13 +101,16 @@ void	suite_42_length_modif_h(t_suite *suite)
 {
 	SUITE_ADD_TEST(suite, test_hd_simple);
 	SUITE_ADD_TEST(suite, test_hd_max);
+	SUITE_ADD_TEST(suite, test_hd_max_plus);
 	SUITE_ADD_TEST(suite, test_hd_min);
 
 	SUITE_ADD_TEST(suite, test_hi_simple);
 	SUITE_ADD_TEST(suite, test_hi_max);
+	SUITE_ADD_TEST(suite, test_hi_max_plus);
 	SUITE_ADD_TEST(suite, test_hi_min);
 
 	SUITE_ADD_TEST(suite, test_hu_max);
+	SUITE_ADD_TEST(suite, test_hu_max_plus);
 	SUITE_ADD_TEST(suite, test_ho_max);
 	SUITE_ADD_TEST(suite, test_hx_max);
 	SUITE_ADD_TEST(suite, test_hX_max);


### PR DESCRIPTION
I just got in 42, sorry if i made a bad move on gits.

I added overflows in tests like it was in the test "hhd" for every type of numbers. In fact, for "short ints" the moulitest originally didn't show any errors if we get the "va_arg" as "int".
