### PR TITLE
Mieux vaut un test asymétrique.

### DIFF
--- a/libft_tests/tests/01_part2_ft_strmapi.spec.c
+++ b/libft_tests/tests/01_part2_ft_strmapi.spec.c
@@ -5,12 +5,13 @@ static void test1(t_test *test)
 	char	*src;
 	char	*dst;
 
-	src = strdup("abcde");
+	src = strdup("eeeee");
 	dst = ft_strmapi(src, mapi_test);
 
-	free(src); src = NULL;
+	free(src);
+	src = NULL;
 
-	mt_assert(strcmp(dst, "acegi") == 0);
+	mt_assert(strcmp(dst, "edcba") == 0);
 }
 
 void	suite_01_part2_ft_strmapi(t_suite *suite)

--- a/libft_tests/utils.c
+++ b/libft_tests/utils.c
@@ -24,5 +24,5 @@ char	map_test(char c)
 
 char	mapi_test(unsigned int i, char c)
 {
-	return (c + i);
+	return (c - i);
 }


### PR DESCRIPTION
J'avais réussi (oui, j'ai honte) à inverser les arguments de la fonction passée en paramètre de ft_strmapi et la moulitest ne l'a pas détecté. C'est parce que l'opération utilisée (l'addition) est symétrique, peu importe l'ordre des arguments. J'ai donc remplacé l'opération et légèrement modifié le test pour mettre une soustraction, qui dépend de l'ordre de ses arguments. ^^
