### PR TITLE
Tried to catch a bad malloc

### DIFF
--- a/libft_tests/tests/02_bonus_ft_lstnew.spec.c
+++ b/libft_tests/tests/02_bonus_ft_lstnew.spec.c
@@ -13,7 +13,25 @@ static void test1(t_test *test)
 	mt_assert((list->content_size) == 0);
 }
 
+static void test2(t_test *test)
+{
+	t_list	*lst;
+	size_t	tl = 50;
+	char	t[tl];
+	char	*bjr;
+
+	memset(t, 'k', tl);
+	lst = ft_lstnew(t, tl);
+	bjr = malloc(10);
+	mt_assert(lst->content != t);
+	mt_assert(memcmp(lst->content, t, tl) == 0);
+	mt_assert(lst->content_size == tl);
+	mt_assert(memcmp(bjr, "kkkkkkkkkk", 10));
+	free(bjr);
+}
+
 void	suite_02_bonus_ft_lstnew(t_suite *suite)
 {
 	SUITE_ADD_TEST(suite, test1);
+	SUITE_ADD_TEST(suite, test2);
 }


### PR DESCRIPTION
Alors. Tout part de ce bug : [juste ici, ligne 31](https://github.com/gaesim/Libft/blob/f0590803d3f5118a762f3f4c711255ebc216defc/ft_lstnew.c)
Le souci, c'est qu'il malloc sizeof(content_size) et qu'il copie la size. Donc j'ai essayé de catch ça en allouant de la mémoire juste derrière, et ça a l'air de marcher (j'ai testé avec ma lib, avec la sienne, la mienne passe, la sienne non à présent).
C'est pas parfait, et honnêtement, je m'étonne même que ça marche. (j'en ai profité pour tester si la mémoire était copiée et non simplement le pointeur)
Je propose quand même ce commit, ne serait-ce que pour soulever le problème. Je sais qu'il y a d'autres façons de faire (en maitrisant le malloc (?) comme dans la libft-unit-test), mais je ne sais pas faire.
