### PR TITLE
GNL: fixed fd leaks

### DIFF
--- a/get_next_line_tests/tests/01_test_simple.spec.c
+++ b/get_next_line_tests/tests/01_test_simple.spec.c
@@ -23,6 +23,7 @@ static void simple_string(t_test *test)
 	mt_assert(strcmp(line, "ccc") == 0);
 	get_next_line(p[0], &line);
 	mt_assert(strcmp(line, "ddd") == 0);
+	close(p[0]);
 }
 
 void	suite_01_test_simple(t_suite *suite)

--- a/get_next_line_tests/tests/02_test_eof_with_close.spec.c
+++ b/get_next_line_tests/tests/02_test_eof_with_close.spec.c
@@ -18,6 +18,7 @@ static void simple_string(t_test *test)
 	gnl_ret = get_next_line(p[0], &line);
 	mt_assert(strcmp(line, "aaa") == 0);
 	mt_assert(gnl_ret == 0 || gnl_ret == 1);
+	close(p[0]);
 }
 
 void	suite_02_test_eof_with_close(t_suite *suite)

--- a/get_next_line_tests/tests/03_test_medium_string.spec.c
+++ b/get_next_line_tests/tests/03_test_medium_string.spec.c
@@ -23,6 +23,7 @@ static void simple_string(t_test *test)
 	gnl_ret = get_next_line(p[0], &line);
 	mt_assert(strcmp(line, str) == 0);
 	mt_assert(gnl_ret == 0 || gnl_ret == 1);
+	close(p[0]);
 }
 
 void	suite_03_test_medium_string(t_suite *suite)

--- a/get_next_line_tests/tests/04_test_return_values.spec.c
+++ b/get_next_line_tests/tests/04_test_return_values.spec.c
@@ -36,6 +36,7 @@ static void simple_string(t_test *test)
 	gnl_ret = get_next_line(p[0], &line);
 	mt_assert(gnl_ret == 0);
 	mt_assert(line == NULL || *line == '\0');
+	close(p[0]);
 }
 
 void	suite_04_test_return_values(t_suite *suite)

--- a/get_next_line_tests/tests/06_test_line_of_08.spec.c
+++ b/get_next_line_tests/tests/06_test_line_of_08.spec.c
@@ -17,6 +17,7 @@ static void simple_string(t_test *test)
 	dup2(out, fd);
 	get_next_line(p[0], &line);
 	mt_assert(strcmp(line, "oiuytrew") == 0);
+	close(p[0]);
 }
 
 void	suite_06_test_line_of_08(t_suite *suite)

--- a/get_next_line_tests/tests/07_test_two_lines_of_08.spec.c
+++ b/get_next_line_tests/tests/07_test_two_lines_of_08.spec.c
@@ -20,6 +20,7 @@ static void simple_string(t_test *test)
 	mt_assert(strcmp(line, "abcdefgh") == 0);
 	get_next_line(p[0], &line);
 	mt_assert(strcmp(line, "ijklmnop") == 0);
+	close(p[0]);
 }
 
 void	suite_07_test_two_lines_of_08(t_suite *suite)

--- a/get_next_line_tests/tests/08_test_few_lines_of_08.spec.c
+++ b/get_next_line_tests/tests/08_test_few_lines_of_08.spec.c
@@ -35,6 +35,7 @@ static void simple_string(t_test *test)
 	mt_assert(strcmp(line, "opqrstuv") == 0);
 	get_next_line(p[0], &line);
 	mt_assert(strcmp(line, "wxyzabcd") == 0);
+	close(p[0]);
 }
 
 void	suite_08_test_few_lines_of_08(t_suite *suite)

--- a/get_next_line_tests/tests/09_test_line_of_16.spec.c
+++ b/get_next_line_tests/tests/09_test_line_of_16.spec.c
@@ -20,6 +20,7 @@ static void simple_string(t_test *test)
 	mt_assert(strcmp(line, "abcdefghijklmnop") == 0);
 	ret = get_next_line(p[0], &line);
 	mt_assert(ret == 0);
+	close(p[0]);
 }
 
 void	suite_09_test_line_of_16(t_suite *suite)

--- a/get_next_line_tests/tests/10_test_two_lines_of_16.spec.c
+++ b/get_next_line_tests/tests/10_test_two_lines_of_16.spec.c
@@ -23,6 +23,7 @@ static void simple_string(t_test *test)
 	mt_assert(strcmp(line, "qrstuvwxyzabcdef") == 0);
 	ret = get_next_line(p[0], &line);
 	mt_assert(ret == 0);
+	close(p[0]);
 }
 
 void	suite_10_test_two_lines_of_16(t_suite *suite)

--- a/get_next_line_tests/tests/11_test_few_lines_of_16.spec.c
+++ b/get_next_line_tests/tests/11_test_few_lines_of_16.spec.c
@@ -38,6 +38,7 @@ static void simple_string(t_test *test)
 	mt_assert(strcmp(line, "stuvwxzabcdefghi") == 0);
 	ret = get_next_line(p[0], &line);
 	mt_assert(ret == 0);
+	close(p[0]);
 }
 
 void	suite_11_test_few_lines_of_16(t_suite *suite)

--- a/get_next_line_tests/tests/12_test_line_of_4.spec.c
+++ b/get_next_line_tests/tests/12_test_line_of_4.spec.c
@@ -20,6 +20,7 @@ static void simple_string(t_test *test)
 	mt_assert(strcmp(line, "abcd") == 0);
 	ret = get_next_line(p[0], &line);
 	mt_assert(ret == 0);
+	close(p[0]);
 }
 
 void	suite_12_test_line_of_4(t_suite *suite)

--- a/get_next_line_tests/tests/13_test_two_lines_of_4.spec.c
+++ b/get_next_line_tests/tests/13_test_two_lines_of_4.spec.c
@@ -23,6 +23,7 @@ static void simple_string(t_test *test)
 	mt_assert(strcmp(line, "efgh") == 0);
 	ret = get_next_line(p[0], &line);
 	mt_assert(ret == 0);
+	close(p[0]);
 }
 
 void	suite_13_test_two_lines_of_4(t_suite *suite)

--- a/get_next_line_tests/tests/14_test_few_lines_of_4.spec.c
+++ b/get_next_line_tests/tests/14_test_few_lines_of_4.spec.c
@@ -38,6 +38,7 @@ static void simple_string(t_test *test)
 	mt_assert(strcmp(line, "yzab") == 0);
 	ret = get_next_line(p[0], &line);
 	mt_assert(ret == 0);
+	close(p[0]);
 }
 
 void	suite_14_test_few_lines_of_4(t_suite *suite)

--- a/get_next_line_tests/tests/15_test_line_without_nl.spec.c
+++ b/get_next_line_tests/tests/15_test_line_without_nl.spec.c
@@ -17,6 +17,7 @@ static void simple_string(t_test *test)
 	dup2(out, fd);
 	get_next_line(p[0], &line);
 	mt_assert(strcmp(line, "abcd") == 0);
+	close(p[0]);
 }
 
 void	suite_15_test_line_without_nl(t_suite *suite)

--- a/get_next_line_tests/tests/16_test_line_of_8_without_nl.spec.c
+++ b/get_next_line_tests/tests/16_test_line_of_8_without_nl.spec.c
@@ -17,6 +17,7 @@ static void simple_string(t_test *test)
 	dup2(out, fd);
 	get_next_line(p[0], &line);
 	mt_assert(strcmp(line, "efghijkl") == 0);
+	close(p[0]);
 }
 
 void	suite_16_test_line_of_8_without_nl(t_suite *suite)

--- a/get_next_line_tests/tests/17_test_line_of_16_without_nl.spec.c
+++ b/get_next_line_tests/tests/17_test_line_of_16_without_nl.spec.c
@@ -17,6 +17,7 @@ static void simple_string(t_test *test)
 	dup2(out, fd);
 	get_next_line(p[0], &line);
 	mt_assert(strcmp(line, "mnopqrstuvwxyzab") == 0);
+	close(p[0]);
 }
 
 void	suite_17_test_line_of_16_without_nl(t_suite *suite)

--- a/get_next_line_tests/tests/30_bonus_multiple_fd.spec.c
+++ b/get_next_line_tests/tests/30_bonus_multiple_fd.spec.c
@@ -69,6 +69,11 @@ static void simple_string(t_test *test)
 
 	get_next_line(p_fd3[0], &line_fd3);
 	mt_assert(strcmp(line_fd3, "999") == 0);
+
+	close(p_fd0[0]);
+	close(p_fd1[0]);
+	close(p_fd2[0]);
+	close(p_fd3[0]);
 }
 
 void	suite_30_bonus_multiple_fd(t_suite *suite)

--- a/get_next_line_tests/tests/40_hard_test_medium_string.spec.c
+++ b/get_next_line_tests/tests/40_hard_test_medium_string.spec.c
@@ -24,6 +24,7 @@ static void test01(t_test *test)
 	dup2(out, 1);
 	get_next_line(p[0], &line);
 	mt_assert(strcmp(line, str) == 0);
+	close(p[0]);
 }
 
 void	suite_40_hard_test_medium_string(t_suite *suite)


### PR DESCRIPTION
Pipes' read ends were left not closed in some tests, causing descriptors to accumulate up to number 42.
This caused test 05 (error handling) to fail when checking with "not opened" fd 42.

This pr may be considered as a fix for #78?