### PR TITLE
fix strcpy test

### DIFF
--- a/libft_tests/tests/00_part1_ft_strcpy.spec.c
+++ b/libft_tests/tests/00_part1_ft_strcpy.spec.c
@@ -8,7 +8,7 @@ static void unittest1(t_test *test)
 	bzero(buf1, 6);
 	bzero(buf2, 6);
 
-	mt_assert(strcmp(ft_strcpy(buf1, "abcde"), strcpy(buf1, "abcde")) == 0);
+	mt_assert(strcmp(ft_strcpy(buf1, "abcde"), strcpy(buf2, "abcde")) == 0);
 }
 
 static void unittest2(t_test *test)
@@ -19,7 +19,7 @@ static void unittest2(t_test *test)
 	bzero(buf1, 6);
 	bzero(buf2, 6);
 
-	mt_assert(strcmp(ft_strcpy(buf1, "abc"), strcpy(buf1, "abc")) == 0);
+	mt_assert(strcmp(ft_strcpy(buf1, "abc"), strcpy(buf2, "abc")) == 0);
 }
 
 void	suite_00_part1_ft_strcpy(t_suite *suite)


### PR DESCRIPTION
ft_strcpy should operate on a different buff than the original strcpy. Otherwise, the test makes no sense.